### PR TITLE
fix: icon for binary sensor uses _icon value

### DIFF
--- a/custom_components/genvex_connect/binary_sensor.py
+++ b/custom_components/genvex_connect/binary_sensor.py
@@ -69,7 +69,7 @@ class GenvexConnectBinarySensorGeneric(GenvexConnectEntityBase, BinarySensorEnti
     @property
     def icon(self):
         """Return the icon of the sensor."""
-        return "mdi:valve"
+        return self._icon
 
     @property
     def is_on(self) -> None:


### PR DESCRIPTION
The binary sensors always displayed an open valve icon, with this change they show the correct icon