### PR TITLE
Add "Alarm active" to support 

### DIFF
--- a/custom_components/genvex_connect/binary_sensor.py
+++ b/custom_components/genvex_connect/binary_sensor.py
@@ -69,7 +69,7 @@ class GenvexConnectBinarySensorGeneric(GenvexConnectEntityBase, BinarySensorEnti
     @property
     def icon(self):
         """Return the icon of the sensor."""
-        return "mdi:valve"
+        return self._icon
 
     @property
     def is_on(self) -> None:

--- a/custom_components/genvex_connect/binary_sensor.py
+++ b/custom_components/genvex_connect/binary_sensor.py
@@ -54,6 +54,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 inverted=True,
             )
         )
+    if genvexNabto.providesValue(GenvexNabtoDatapointKey.ALARM_ACTIVE):
+        new_entities.append(
+            GenvexConnectBinarySensorGeneric(
+                genvexNabto,
+                GenvexNabtoDatapointKey.ALARM_ACTIVE,
+                "mdi:alarm-light",
+                type=BinarySensorDeviceClass.PROBLEM,
+            )
+        )
 
     async_add_entities(new_entities)
 

--- a/custom_components/genvex_connect/strings.json
+++ b/custom_components/genvex_connect/strings.json
@@ -53,6 +53,9 @@
       },      
       "defrost_active": {
         "name": "Defrost active"
+      },
+      "alarm_active": {
+        "name": "Alarm active"
       }
     },
     "climate": {
@@ -181,7 +184,7 @@
           "state_4194304": "Fire Box 2 failure",
           "state_8388608": "Rotor alarm"
         }
-      }   
+      } 
     },
     "switch": {
       "humidity_control": {


### PR DESCRIPTION
**This pull request is dependent on the pull request: https://github.com/superrob/genvexnabto/pull/2**

The solution currently runs in my current installation, but since I'm not a python programmer, this most likely needs a new set of eyes going over the changes.

**There is an issue with this i just cannot seem to fix.**
The entity gets the name "<device_id>_problem" instead of "<device_id>_alarm_active"
Why i do not know.

