### PR TITLE
CTS400 - Added ON/OFF switch

### DIFF
--- a/custom_components/genvex_connect/strings.json
+++ b/custom_components/genvex_connect/strings.json
@@ -204,6 +204,9 @@
       },
       "boost_enable": {
         "name": "Boost"
+      },
+      "ventilation_enable": {
+        "name": "Ventilation"
       }
     },
     "select": {

--- a/custom_components/genvex_connect/switch.py
+++ b/custom_components/genvex_connect/switch.py
@@ -22,6 +22,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         new_entities.append(GenvexConnectSwitch(genvexNabto, GenvexNabtoSetpointKey.HUMIDITY_CONTROL, "mdi:water-circle"))
     if genvexNabto.providesValue(GenvexNabtoSetpointKey.BOOST_ENABLE):
         new_entities.append(GenvexConnectSwitch(genvexNabto, GenvexNabtoSetpointKey.BOOST_ENABLE, "mdi:fan-chevron-up"))
+    if genvexNabto.providesValue(GenvexNabtoSetpointKey.VENTILATION_ENABLE):
+        new_entities.append(GenvexConnectSwitch(genvexNabto, GenvexNabtoSetpointKey.VENTILATION_ENABLE, "mdi:fan"))
 
     async_add_entities(new_entities)
 

--- a/custom_components/genvex_connect/translations/da.json
+++ b/custom_components/genvex_connect/translations/da.json
@@ -204,6 +204,9 @@
       },
       "boost_enable": {
         "name": "Boost"
+      },
+      "ventilation_enable": {
+        "name": "Ventilation"
       }
     },
     "select": {

--- a/custom_components/genvex_connect/translations/en.json
+++ b/custom_components/genvex_connect/translations/en.json
@@ -207,6 +207,9 @@
       },
       "boost_enable": {
         "name": "Boost"
+      },
+      "ventilation_enable": {
+        "name": "Ventilation"
       }
     },
     "select": {


### PR DESCRIPTION
Related to https://github.com/superrob/genvexnabto/pull/4

The CTS400 unit does not support setting fan speed to step 0, but needs to set the on/off setting via a separate address.

**PREREQUISITES**: 
- https://github.com/superrob/genvexnabto/pull/4